### PR TITLE
Fix for cookie request issue.

### DIFF
--- a/espn-request.js
+++ b/espn-request.js
@@ -16,8 +16,8 @@ function requestToPromise(url, cookies){
     domain : 'espn.com'
   });
 
-  cookieJar.setCookie(espnS2, 'http://games.espn.com/');
-  cookieJar.setCookie(SWID, 'http://games.espn.com/');
+  cookieJar.setCookie(espnS2.toString(), 'http://games.espn.com/');
+  cookieJar.setCookie(SWID.toString(), 'http://games.espn.com/');
 
   const options = {
     method : 'GET',


### PR DESCRIPTION
I was receiving:
 `TypeError: str.trim is not a function`

for every request I issued. 

After some reading around I found that this: https://github.com/request/request-promise/issues/183#issuecomment-397586027 fixed the issue for me. 